### PR TITLE
修复蓝色背景/top无隐藏bug

### DIFF
--- a/css/PureSuck_Module.css
+++ b/css/PureSuck_Module.css
@@ -72,7 +72,7 @@
     background-color: var(--themecolor);
     color: var(--pure-color);
     opacity: 0;
-    visibility: hidden; /* 默认隐藏 */
+    visibility: hidden; /* 隐藏 */
     pointer-events: none; /* 默认禁用点击 */
     border-radius: 14px;
     cursor: pointer;
@@ -82,7 +82,7 @@
 
 #go-top.visible {
     opacity: 1;
-    visibility: visible; /* 显示按钮 */
+    visibility: visible; /* 显示 */
     pointer-events: auto; /* 启用点击 */
 }
 

--- a/css/PureSuck_Module.css
+++ b/css/PureSuck_Module.css
@@ -72,6 +72,8 @@
     background-color: var(--themecolor);
     color: var(--pure-color);
     opacity: 0;
+    visibility: hidden; /* 默认隐藏 */
+    pointer-events: none; /* 默认禁用点击 */
     border-radius: 14px;
     cursor: pointer;
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
@@ -80,7 +82,8 @@
 
 #go-top.visible {
     opacity: 1;
-    visibility: visible;
+    visibility: visible; /* 显示按钮 */
+    pointer-events: auto; /* 启用点击 */
 }
 
 .go-top:hover {

--- a/css/PureSuck_Style.css
+++ b/css/PureSuck_Style.css
@@ -222,7 +222,8 @@ table tr:has(td):hover {
 a,
 a:after,
 a:before {
-	text-decoration: none
+	text-decoration: none;
+	-webkit-tap-highlight-color: transparent; /* 去除浏览器按压反馈 */
 }
 
 h1 a,

--- a/header.php
+++ b/header.php
@@ -90,6 +90,9 @@
                 updateIcon('auto');
             }
         });
+            *{
+            -webkit-tap-highlight-color:rgba(0,0,0,0);
+            }
     </script>
     <!-- Style CSS -->
     <link rel="stylesheet" href="<?= $this->options->themeUrl('css/PureSuck_Style.css'); ?>">

--- a/header.php
+++ b/header.php
@@ -90,9 +90,6 @@
                 updateIcon('auto');
             }
         });
-            *{
-            -webkit-tap-highlight-color:rgba(0,0,0,0);
-            }
     </script>
     <!-- Style CSS -->
     <link rel="stylesheet" href="<?= $this->options->themeUrl('css/PureSuck_Style.css'); ?>">

--- a/js/PureSuck_Module.js
+++ b/js/PureSuck_Module.js
@@ -2,7 +2,7 @@
 /** 回到顶部按钮，TOC目录，内部卡片部分内容解析都在这里 **/
 
 function handleGoTopButton() {
-    const goTopBtn = document.getElementById('go-top');
+    const goTopBtn = document.getElementById('go-top'); // 按钮容器
     const goTopAnchor = document.querySelector('#go-top .go');
 
     window.addEventListener('scroll', () => {
@@ -20,12 +20,10 @@ function handleGoTopButton() {
             behavior: 'smooth'
         });
         setTimeout(() => {
-            goTopBtn.classList.remove('visible'); // 隐藏按钮
+            goTopBtn.classList.remove('visible'); // 隐藏
         }, 400); // 等待滚动完成
     });
 }
-handleGoTopButton();
-
 
 function generateTOC() {
     const tocSection = document.getElementById("toc-section");

--- a/js/PureSuck_Module.js
+++ b/js/PureSuck_Module.js
@@ -3,26 +3,29 @@
 
 function handleGoTopButton() {
     const goTopBtn = document.getElementById('go-top');
-    const observer = new IntersectionObserver(entries => {
-        entries.forEach(entry => {
-            if (entry.boundingClientRect.top < 0) {
-                goTopBtn.classList.add('visible');
-            } else {
-                goTopBtn.classList.remove('visible');
-            }
-        });
-    });
-    observer.observe(document.body);
-
     const goTopAnchor = document.querySelector('#go-top .go');
+
+    window.addEventListener('scroll', () => {
+        if (window.scrollY > 100) {
+            goTopBtn.classList.add('visible'); // 显示按钮
+        } else {
+            goTopBtn.classList.remove('visible'); // 隐藏按钮
+        }
+    });
+
     goTopAnchor.addEventListener('click', function (e) {
         e.preventDefault();
         window.scrollTo({
             top: 0,
             behavior: 'smooth'
         });
+        setTimeout(() => {
+            goTopBtn.classList.remove('visible'); // 隐藏按钮
+        }, 400); // 等待滚动完成
     });
 }
+handleGoTopButton();
+
 
 function generateTOC() {
     const tocSection = document.getElementById("toc-section");


### PR DESCRIPTION
更换top的监听为scroll事件，修复回到顶部会按钮依然可以点击的bug并重置了top的js代码，现在的js监听更适合博客场景
添加top默认隐藏禁用两个小css，以适配修复的js代码
header文件内添加头css代码解决手机端的链接/图片点击/长按出现蓝色背景框问题
我看作者没时间更新就提交一下我的修复供作者参考罢🌚