### PR TITLE
修复：恢复顶层有序/无序列表标记

### DIFF
--- a/css/PureSuck_Style.css
+++ b/css/PureSuck_Style.css
@@ -2545,9 +2545,9 @@ input:-webkit-autofill:active {
 		contain-intrinsic-size: auto 260px;
 	}
 
-	/* 标题有装饰伪元素，排除避免裁切 */
-	.post.post--single .post-content > :is(h1, h2, h3, h4, h5, h6),
-	.post[data-ps-page-shell="page"] .post-content > :is(h1, h2, h3, h4, h5, h6) {
+	/* 标题装饰和列表外置 marker 需要避免裁切 */
+	.post.post--single .post-content > :is(h1, h2, h3, h4, h5, h6, ol, ul),
+	.post[data-ps-page-shell="page"] .post-content > :is(h1, h2, h3, h4, h5, h6, ol, ul) {
 		content-visibility: visible;
 		contain: none;
 	}


### PR DESCRIPTION
### Motivation
- 修复 Issue #61 中顶层文章列表（顶级 `ol`/`ul`）的序号和圆点被隐藏的问题。 
- 问题来源于正文每个直接子元素使用 `content-visibility: auto` 作为渲染岛时，外置的列表 `::marker` 会被 containment 裁切，需要对顶层列表做精准排除以保持懒渲染优势。 

### Description
- 在 `css/PureSuck_Style.css` 的 `@supports (content-visibility: auto)` 块中，将顶层选择器扩展为 `> :is(h1, h2, h3, h4, h5, h6, ol, ul)`，使顶层 `ol`/`ul` 被排除在裁切之外并应用 `content-visibility: visible; contain: none;`。 
- 保留并未修改现有正文列表排版规则（`list-style-position: outside`、有序 `decimal`、无序 `disc` 和嵌套 `circle` → `square` 等）。 
- 此改动只针对顶层列表的可视裁切排除，继续保留块级懒渲染优化以避免关闭全页面的 `content-visibility`。 

### Testing
- 运行了 PHP 语法检查 `for file in *.php functions/*.php; do php -l "$file" >/dev/null; done`，结果通过。 
- 运行了脚本断言 CSS 结构（验证 `@supports` 渲染岛规则、顶层 `ol`/`ul` 的排除规则以及列表层级样式存在），断言通过。 
- 运行了差异检查 `git diff --check` 与相关静态检查，均未发现问题；环境中没有可用的 Chromium/Playwright，故未进行浏览器截图级视觉回归。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e53c9953083288653d562f53d0cca)